### PR TITLE
Fix Gen instance unavailability

### DIFF
--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -45,7 +45,6 @@ func main() {
 		usage()
 		return
 	}
-
 	newSrc, err := generator.Rewrite(file)
 	if err != nil {
 		panic(err)
@@ -56,7 +55,6 @@ func main() {
 		return
 	}
 
-	// write to the source file
 	f, err := os.OpenFile(file, os.O_RDWR, 0666)
 	if err != nil {
 		fmt.Printf("open %s error: %v\n", file, err)

--- a/examples/gen-demo/main.go
+++ b/examples/gen-demo/main.go
@@ -1,6 +1,6 @@
 package main
 
-//go:generate ../../gen -w main.go
+//go:generate go run ../../cmd/gen/main.go -w main.go
 
 import "sync"
 


### PR DESCRIPTION
In go 1.15, the local running prompt permission is not enough, that is, the main file under Gen is not used automatically, and there is one more CMD in the file directory. After modifying the directory, you will be prompted with foramt err. It seems that the go run instruction is missing

```
//go:generate  ../../gen  -w
更改
//go:generate go run ../../cmd/gen/main.go -w main.go
```
